### PR TITLE
Update Flask to avoid error ImportError: cannot import name 'Markup' …

### DIFF
--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.2
+Flask==2.0.3
 requests==2.21.0
 requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
Update Flask to avoid error ImportError: cannot import name 'Markup' from 'jinja2'

https://stackoverflow.com/questions/71645272/importerror-cannot-import-name-markup-from-jinja2 

https://github.com/pifou25/jeedom-lgthinq-plugin/issues/8